### PR TITLE
Modernize python 2 codes

### DIFF
--- a/test/support/filesystem_dynamic_test_helper.py
+++ b/test/support/filesystem_dynamic_test_helper.py
@@ -75,7 +75,7 @@ def create_fifo(source):
 
 
 def create_socket(source):
-    mode = 0600|stat.S_IFSOCK
+    mode = 0o600 | stat.S_IFSOCK
     os.mknod(sanitize(source), mode)
 
 

--- a/utils/google-benchmark/tools/compare_bench.py
+++ b/utils/google-benchmark/tools/compare_bench.py
@@ -3,6 +3,7 @@
 compare_bench.py - Compare two benchmarks or their results and report the
                    difference.
 """
+from __future__ import print_function
 import sys
 import gbench
 from gbench import util, report
@@ -21,7 +22,7 @@ def main():
     json1 = gbench.util.run_or_load_benchmark(tests[0], bench_opts)
     json2 = gbench.util.run_or_load_benchmark(tests[1], bench_opts)
     output_lines = gbench.report.generate_difference_report(json1, json2)
-    print 'Comparing %s to %s' % (tests[0], tests[1])
+    print('Comparing %s to %s' % (tests[0], tests[1]))
     for ln in output_lines:
         print(ln)
 

--- a/utils/google-benchmark/tools/gbench/report.py
+++ b/utils/google-benchmark/tools/gbench/report.py
@@ -1,5 +1,6 @@
 """report.py - Utilities for reporting statistics about benchmark results
 """
+from __future__ import print_function
 import os
 
 class BenchmarkColor(object):
@@ -124,7 +125,7 @@ class TestReportDifference(unittest.TestCase):
         ]
         json1, json2 = self.load_results()
         output_lines = generate_difference_report(json1, json2, use_color=False)
-        print output_lines
+        print(output_lines)
         self.assertEqual(len(output_lines), len(expect_lines))
         for i in xrange(0, len(output_lines)):
             parts = [x for x in output_lines[i].split(' ') if x]

--- a/utils/google-benchmark/tools/gbench/util.py
+++ b/utils/google-benchmark/tools/gbench/util.py
@@ -1,5 +1,6 @@
 """util.py - General utilities for running, loading, and processing benchmarks
 """
+from __future__ import print_function
 import json
 import os
 import tempfile
@@ -80,7 +81,7 @@ def check_input_file(filename):
     """
     ftype, msg = classify_input_file(filename)
     if ftype == IT_Invalid:
-        print "Invalid input file: %s" % msg
+        print("Invalid input file: %s" % msg)
         sys.exit(1)
     return ftype
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Also, __0600__ is a syntax error in Python 3 but __0o600__ works as expected in both Python 2 and Python 3.